### PR TITLE
ci(release): scope NPM_TOKEN to the publish steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual run from a branch whose package.json version is not on npm yet
+  # (e.g. to publish after configuring the token or trusted publishing).
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      TRUSTED_PUBLISHING: ${{ vars.NPM_TRUSTED_PUBLISHING }}
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +24,9 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      # The npm token is deliberately NOT exposed to install/test/build: a compromised
+      # dependency's postinstall or test code must never be able to read it. Only the two
+      # steps below (mode detection and the token publish) receive it.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -36,21 +36,28 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Check whether this version is already on npm
-        id: published
+      - name: Decide how to publish
+        id: mode
         working-directory: packages/cli
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TRUSTED_PUBLISHING: ${{ vars.NPM_TRUSTED_PUBLISHING }}
         run: |
           V=$(node -p "require('./package.json').version")
           if npm view "@stroq/cli@$V" version >/dev/null 2>&1; then
-            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "mode=already-published" >> "$GITHUB_OUTPUT"
             echo "@stroq/cli@$V is already published; skipping"
+          elif [ -n "$NPM_TOKEN" ]; then
+            echo "mode=token" >> "$GITHUB_OUTPUT"
+          elif [ "$TRUSTED_PUBLISHING" = "true" ]; then
+            echo "mode=trusted" >> "$GITHUB_OUTPUT"
           else
-            echo "already=false" >> "$GITHUB_OUTPUT"
+            echo "mode=none" >> "$GITHUB_OUTPUT"
           fi
 
       # Path 1: an npm granular access token stored as the NPM_TOKEN repository secret.
       - name: Publish to npm (token)
-        if: steps.published.outputs.already != 'true' && env.NPM_TOKEN != ''
+        if: steps.mode.outputs.mode == 'token'
         working-directory: packages/cli
         run: npm publish --provenance --access public
         env:
@@ -60,11 +67,11 @@ jobs:
       # enabled by setting the repository variable NPM_TRUSTED_PUBLISHING=true. No secret needed;
       # provenance attestations are generated automatically.
       - name: Publish to npm (trusted publishing)
-        if: steps.published.outputs.already != 'true' && env.NPM_TOKEN == '' && env.TRUSTED_PUBLISHING == 'true'
+        if: steps.mode.outputs.mode == 'trusted'
         working-directory: packages/cli
         run: npm publish --access public
 
       - name: Publishing not configured
-        if: steps.published.outputs.already != 'true' && env.NPM_TOKEN == '' && env.TRUSTED_PUBLISHING != 'true'
+        if: steps.mode.outputs.mode == 'none'
         run: |
           echo "::warning::Nothing published: set the NPM_TOKEN secret or configure npm trusted publishing and set the NPM_TRUSTED_PUBLISHING repository variable to true, then re-run this workflow."


### PR DESCRIPTION
Security-review follow-up: the previous release.yml put the NPM_TOKEN secret in the job-level env, so pnpm install/test/build (and any dependency postinstall) could read it. The token is now passed only to the mode-detection step and the token-publish step; install/test/build run without it. Behaviour is otherwise unchanged (token, trusted publishing, or a warning).