### PR TITLE
ci: pin actions to commit SHAs; manual release runs only from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,17 @@ permissions:
 
 jobs:
   publish:
+    # Tag pushes always run; manual runs are only honoured from main, so nobody can
+    # publish an unreviewed branch by dispatching the workflow against it.
+    if: github.event_name == 'push' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       # Node 24 ships npm 11.x, which trusted publishing (OIDC) requires (>= 11.5.1).
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
Security-review follow-up (ci-cd-trust): actions/checkout, pnpm/action-setup and actions/setup-node are now pinned to the commit SHAs of their v4.4.0 tags in both workflows (a moved or compromised tag can no longer change what runs with the npm credential or the OIDC token), and the release job only honours workflow_dispatch from main, so an unreviewed branch cannot be published by dispatching the workflow against it. Tag-triggered releases are unchanged.