### PR TITLE
chore: ignore Vercel link files at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ coverage/
 # Vercel link files for the website (site/)
 site/.vercel/
 site/.env*
+.vercel
+.env*


### PR DESCRIPTION
The Vercel project is now linked at the repo root with Root Directory = site (for the GitHub integration and for deploys from the root); the link files must stay untracked.