### PR TITLE
feat(site): Vercel Web Analytics

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -28,6 +28,7 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&display=swap">
 <link rel="stylesheet" href="/styles.css">
 <script src="/main.js" defer></script>
+<script src="/_vercel/insights/script.js" defer></script>
 </head>
 <body>
 <a class="skip" href="#main">Skip to content</a>

--- a/site/main.js
+++ b/site/main.js
@@ -1,6 +1,13 @@
 /* Stroq site — progressive enhancement only.
    Everything renders without this file; it adds the menu toggle, copy buttons,
-   scroll reveals and the hero terminal animation. No network, no storage. */
+   scroll reveals and the hero terminal animation. No storage. The only network
+   call is Vercel Web Analytics (cookieless page views, first-party route),
+   whose deferred script loads after this file. */
+window.va =
+  window.va ||
+  function () {
+    (window.vaq = window.vaq || []).push(arguments);
+  };
 (function () {
   'use strict';
 

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -6,7 +6,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'"
         },
         {
           "key": "Strict-Transport-Security",


### PR DESCRIPTION
Adds Vercel Web Analytics to the static site: the deferred first-party script (/_vercel/insights/script.js) after main.js, the window.va queue stub in main.js (kept out of inline script so the CSP stays script-src 'self'), and connect-src 'self' in site/vercel.json so the page-view beacon is allowed. Cookieless; no third-party hosts added. Web Analytics must be enabled for the project in the Vercel dashboard for the route to exist.