### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
   "metadata": {
     "description": "Stroq — local action firewall for AI coding agents",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "stroq",
       "source": "./plugins/stroq",
       "description": "Local action firewall for Claude Code: content scan + session taint, instruction provenance, secret egress guard, ordered policy, hash-chained audit. Runs offline through native hooks.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "homepage": "https://stroq.vercel.app",
       "license": "Apache-2.0",
       "keywords": ["security", "firewall", "prompt-injection", "secrets", "provenance", "audit"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-09-05
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stroq-monorepo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroq/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Local action firewall for AI agents: scans what the agent reads, taints the session, blocks dangerous follow-up actions",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroq/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Stroq core: normalizer, ATR-compatible rule matcher, action classifier, taint-aware policy, audit chain",
   "license": "Apache-2.0",
   "private": true,

--- a/plugins/stroq/.claude-plugin/plugin.json
+++ b/plugins/stroq/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stroq",
   "description": "Local action firewall for Claude Code: scans what the agent reads, taints the session, attributes commands to the content they came from, denies outbound calls that carry your secrets, and asks before destructive or external actions. Deterministic, offline, hash-chained audit.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
   "homepage": "https://stroq.vercel.app",
   "repository": "https://github.com/AGGIB/Stroq",

--- a/plugins/stroq/hooks/stroq-hook.sh
+++ b/plugins/stroq/hooks/stroq-hook.sh
@@ -13,7 +13,7 @@
 # "block". PostToolUse events fail open in that case, because the tool has
 # already run and there is nothing left to block.
 set -u
-STROQ_PIN="@stroq/cli@0.3.0"
+STROQ_PIN="@stroq/cli@0.4.0"
 
 input="$(cat)"
 


### PR DESCRIPTION
Release preparation for 0.4.0 (Cursor adapter, Claude Code plugin/marketplace, site analytics — all already on main): versions 0.3.0 → 0.4.0 in root, core, cli, the plugin manifest and the marketplace entry; the plugin wrapper's npx pin moves to @stroq/cli@0.4.0; CHANGELOG [Unreleased] → [0.4.0] - 2026-09-05. Tests 744, format and plugin validation clean. After merge: tag v0.4.0 (release.yml publishes via trusted publishing) and the GitHub Release.