### PR TITLE
docs: total npm downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Scans what the agent reads. Taints the session. Blocks the dangerous follow-up â
 [![CI](https://github.com/AGGIB/Stroq/actions/workflows/ci.yml/badge.svg)](https://github.com/AGGIB/Stroq/actions/workflows/ci.yml)
 [![stroq attack: 12/12 stopped](https://img.shields.io/badge/stroq%20attack-12%2F12%20stopped-1f9d55)](#replay-twelve-real-incidents)
 [![npm version](https://img.shields.io/npm/v/%40stroq%2Fcli?logo=npm&logoColor=white&label=npm&color=cb3837)](https://www.npmjs.com/package/@stroq/cli)
-[![npm downloads](https://img.shields.io/npm/dm/%40stroq%2Fcli?label=downloads&color=0b7285)](https://www.npmjs.com/package/@stroq/cli)
+[![npm downloads](https://img.shields.io/npm/d18m/%40stroq%2Fcli?label=downloads&color=0b7285)](https://www.npmjs.com/package/@stroq/cli)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Node >= 22](https://img.shields.io/badge/node-%3E%3D22-339933?logo=node.js&logoColor=white)](package.json)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://github.com/AGGIB/Stroq/actions/workflows/ci.yml"><img src="https://github.com/AGGIB/Stroq/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://www.npmjs.com/package/@stroq/cli"><img src="https://img.shields.io/npm/v/%40stroq%2Fcli?logo=npm&logoColor=white&label=npm&color=cb3837" alt="npm version"></a>
-  <a href="https://www.npmjs.com/package/@stroq/cli"><img src="https://img.shields.io/npm/dm/%40stroq%2Fcli?label=downloads&color=0b7285" alt="npm downloads"></a>
+  <a href="https://www.npmjs.com/package/@stroq/cli"><img src="https://img.shields.io/npm/d18m/%40stroq%2Fcli?label=downloads&color=0b7285" alt="npm downloads"></a>
   <a href="https://github.com/AGGIB/Stroq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License: Apache 2.0"></a>
 </p>
 


### PR DESCRIPTION
## Why

The README downloads badge shows `0/month` while npm already counts 63 downloads on 2026-09-04. shields' `npm/dm` reads npm's *point* endpoints (`last-week`/`last-month`), whose window currently ends on 2026-08-29, a week behind. `npm/d18m` (the target of the old `npm/dt`) sums the day-by-day *range* endpoint, which is current; for a package younger than 18 months it is the all-time total.

## What

- `README.md` and `packages/cli/README.md`: `npm/dm` → `npm/d18m`, label unchanged.

## Test plan

- [x] `https://img.shields.io/npm/d18m/%40stroq%2Fcli.json` returns `{"message":"63"}` today, while `npm/dm` returns `0/month`.
- [ ] Badge renders `downloads 63` on the GitHub README after merge (shields caches for about five minutes).