### PR TITLE
chore: ignore .superpowers/ and .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ site/.vercel/
 site/.env*
 .vercel
 .env*
+
+# Session scratch: SDD ledgers/review packages and launch drafts (never published)
+.superpowers/
+# Claude Code worktrees created by EnterWorktree
+.claude/worktrees/


### PR DESCRIPTION
`.superpowers/` holds the subagent-driven-development ledgers, review packages and launch drafts; `.claude/worktrees/` is where Claude Code's `EnterWorktree` puts worktrees. Both showed up as untracked in `git status` on `main`, so a careless `git add -A` would have committed private drafts and full review diffs. Only `.worktrees/` was ignored before.

- [x] `git check-ignore` confirms both paths are ignored
- [ ] CI green