### PR TITLE
chore(npm): dual-use disclosure and staged publishing; 0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
   "metadata": {
     "description": "Stroq — local action firewall for AI coding agents",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {
       "name": "stroq",
       "source": "./plugins/stroq",
       "description": "Local action firewall for Claude Code: content scan + session taint, instruction provenance, secret egress guard, ordered policy, hash-chained audit. Runs offline through native hooks.",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "homepage": "https://stroq.vercel.app",
       "license": "Apache-2.0",
       "keywords": ["security", "firewall", "prompt-injection", "secrets", "provenance", "audit"],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,21 +61,31 @@ jobs:
             echo "mode=none" >> "$GITHUB_OUTPUT"
           fi
 
+      # @stroq/cli is declared dual-use (packages/cli/DISCLOSURE): it reads credential files to
+      # hash them, installs hooks into other tools' config and ships an attack corpus. npm's
+      # dual-use policy requires such packages to be published with 2FA — interactively, or by
+      # staging from CI and approving with 2FA — so CI only STAGES the version. A maintainer then
+      # approves it on npmjs.com (Staged Packages → Approve) or with `npm stage approve <id>`.
       # Path 1: an npm granular access token stored as the NPM_TOKEN repository secret.
-      - name: Publish to npm (token)
+      - name: Stage on npm (token)
         if: steps.mode.outputs.mode == 'token'
         working-directory: packages/cli
-        run: npm publish --provenance --access public
+        run: npm stage publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Path 2: npm trusted publishing (OIDC) configured for this repo/workflow on npmjs.com,
-      # enabled by setting the repository variable NPM_TRUSTED_PUBLISHING=true. No secret needed;
-      # provenance attestations are generated automatically.
-      - name: Publish to npm (trusted publishing)
+      # Path 2: npm trusted publishing (OIDC) configured for this repo/workflow on npmjs.com with
+      # stage-publish allowed, enabled by setting the repository variable
+      # NPM_TRUSTED_PUBLISHING=true. No secret needed; provenance is attached automatically.
+      - name: Stage on npm (trusted publishing)
         if: steps.mode.outputs.mode == 'trusted'
         working-directory: packages/cli
-        run: npm publish --access public
+        run: npm stage publish --access public
+
+      - name: Staged, awaiting approval
+        if: steps.mode.outputs.mode == 'token' || steps.mode.outputs.mode == 'trusted'
+        run: |
+          echo "::notice::@stroq/cli is staged. Approve it with 2FA on npmjs.com (Staged Packages) or run: npm stage list && npm stage approve <stage-id>"
 
       - name: Publishing not configured
         if: steps.mode.outputs.mode == 'none'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-09-05
+
+### Changed
+
+- **npm dual-use disclosure.** `@stroq/cli` now declares `"contentPolicy": { "class": "dual-use" }` in its `package.json` and ships a `DISCLOSURE` file, per npm's dual-use content policy: the package reads credential files (to hash them for the secret egress guard), installs hooks into other programs' configuration (on `stroq init`) and carries an attack corpus and a prompt-injection rule bundle, all of which resemble malware to npm's publish-time scanner. Versions 0.3.0, 0.4.0 and 0.5.0 were accepted by the registry but held for manual review and never became installable; nothing in the code changed for this release.
+- **Release workflow publishes to npm's staging area.** Dual-use packages must be published with 2FA, so `release.yml` now runs `npm stage publish` (trusted publishing or token) and a maintainer approves the staged version on npmjs.com or with `npm stage approve` after a 2FA prompt, instead of publishing directly.
+
 ## [0.5.0] - 2026-09-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stroq-monorepo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/DISCLOSURE
+++ b/packages/cli/DISCLOSURE
@@ -1,0 +1,68 @@
+Dual-use disclosure for @stroq/cli
+===================================
+
+Stroq is an open-source (Apache-2.0) local "action firewall" for AI coding
+agents such as Claude Code, Cursor and OpenAI Codex CLI. It is a defensive
+security tool. It runs entirely on the developer's own machine, and it makes
+no network requests of its own: the strings `fetch(`, `curl ... | sh`,
+`base64 -d`, `~/.ssh/id_rsa` and similar that appear in this package are
+detection rules and recorded attack fixtures, not code paths that execute
+them. Source, tests and the rule corpus: https://github.com/AGGIB/Stroq
+
+Why an automated scanner may flag this package
+----------------------------------------------
+
+1. It reads credential files, locally, to protect them.
+   `stroq` builds an index of secret VALUES from the project's `.env*` files
+   and from `~/.aws/credentials`, `~/.npmrc`, `~/.netrc` and
+   `~/.docker/config.json`, so that it can refuse any agent action whose
+   arguments would send one of those values somewhere (the "secret egress
+   guard"). Only salted SHA-256 hashes are stored (`~/.stroq/secrets.json`);
+   the values themselves are never written to disk, never logged, never
+   transmitted, and are redacted from the audit trail. Credential-shaped
+   environment variables are hashed in memory only.
+
+2. It installs hooks into other programs' configuration, on request.
+   `stroq init` writes hook entries into `.claude/settings.json`,
+   `.cursor/hooks.json` or `.codex/hooks.json` (project or user scope), so the
+   agent calls `stroq hook <agent>` before and after each tool use. It only
+   does this when the user runs `stroq init`; it never modifies those files
+   otherwise, and it refuses to let a compromised agent session modify them.
+
+3. It ships an attack corpus.
+   `stroq attack` replays twelve recorded, incident-backed prompt-injection
+   scenarios (a protestware README, poisoned MCP results, `curl | sh`
+   installers, base64-encoded installers, a `~/.ssh/id_rsa` fetch, `rm -rf ~`,
+   secret exfiltration through `curl`) through the user's own policy in
+   throwaway directories, and reports which ones were blocked. The payloads
+   are data used to test the firewall; nothing in them is executed.
+
+4. It contains a large prompt-injection rule bundle.
+   Hundreds of regular expressions (Agent Threat Rules format) describe
+   malicious instructions so that they can be recognised in files, web pages,
+   MCP responses and command output that an agent reads. Their text
+   necessarily looks like the attacks they detect.
+
+What the package does not do
+----------------------------
+
+- No network I/O, no telemetry, no remote configuration, no auto-update.
+- No install-time scripts (`preinstall`/`postinstall`/`prepare`).
+- No reading of secrets beyond the files listed above, and no use of their
+  values other than comparing hashes.
+- No modification of any file except `~/.stroq/*` (its own state), the
+  agent hook files written by an explicit `stroq init`, and the temporary
+  directories `stroq attack` creates and removes for its replay.
+
+Intended legitimate use
+-----------------------
+
+Developers and security teams install it next to their AI coding agent so
+that a prompt injection in a README, an issue comment, a web page or an MCP
+result cannot turn into a `curl | sh`, a credential exfiltration, a
+destructive command or a self-disabling edit of the agent's configuration.
+Every decision is written to a hash-chained local audit log (`stroq log`,
+`stroq verify`, `stroq why`).
+
+Contact: https://github.com/AGGIB/Stroq/issues (security reports: see
+SECURITY.md in the repository).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroq/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Local action firewall for AI agents: scans what the agent reads, taints the session, blocks dangerous follow-up actions",
   "license": "Apache-2.0",
   "type": "module",
@@ -10,8 +10,12 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "DISCLOSURE"
   ],
+  "contentPolicy": {
+    "class": "dual-use"
+  },
   "engines": {
     "node": ">=22"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroq/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Stroq core: normalizer, ATR-compatible rule matcher, action classifier, taint-aware policy, audit chain",
   "license": "Apache-2.0",
   "private": true,

--- a/plugins/stroq/.claude-plugin/plugin.json
+++ b/plugins/stroq/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stroq",
   "description": "Local action firewall for Claude Code: scans what the agent reads, taints the session, attributes commands to the content they came from, denies outbound calls that carry your secrets, and asks before destructive or external actions. Deterministic, offline, hash-chained audit.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
   "homepage": "https://stroq.vercel.app",
   "repository": "https://github.com/AGGIB/Stroq",

--- a/plugins/stroq/hooks/stroq-hook.sh
+++ b/plugins/stroq/hooks/stroq-hook.sh
@@ -13,7 +13,7 @@
 # "block". PostToolUse events fail open in that case, because the tool has
 # already run and there is nothing left to block.
 set -u
-STROQ_PIN="@stroq/cli@0.5.0"
+STROQ_PIN="@stroq/cli@0.5.1"
 
 input="$(cat)"
 


### PR DESCRIPTION
## Why

npm scans every publish since July 2026 and holds suspicious versions for manual review. `@stroq/cli` 0.3.0, 0.4.0 and 0.5.0 were all accepted (`+ @stroq/cli@x.y.z`, provenance attested) but never became installable: to the scanner the package looks like an infostealer — it reads `.env`, `~/.aws/credentials`, `~/.npmrc`, `~/.netrc`, `~/.docker/config.json` (to hash them for the secret egress guard), installs hooks into other tools' config, and ships `curl | sh` / base64-installer / `id_rsa` strings in the attack corpus and the rule bundle. npm's [dual-use content policy](https://docs.npmjs.com/policies/dual-use) covers exactly this: declare `contentPolicy.class = "dual-use"`, ship a `DISCLOSURE` file, and publish with 2FA (interactively, or by staging from CI and approving with 2FA) — direct OIDC/token publishing is not permitted for dual-use packages, which is the path we were using.

## What

- `packages/cli/package.json`: `"contentPolicy": { "class": "dual-use" }`; `DISCLOSURE` added to `files` (verified in the packed tarball next to `LICENSE`).
- `packages/cli/DISCLOSURE`: what the tool does and why it looks dual-use (credential files hashed locally, hooks installed only on `stroq init`, attack corpus and rule bundle are data), what it does not do (no network I/O — verified: the `fetch(`/`https.request(` strings in the bundle all come from `rules.bundle.json`; no install scripts), intended use.
- `release.yml`: both publish paths now run `npm stage publish`; a maintainer approves on npmjs.com (Staged Packages → Approve) or with `npm stage approve <id>` after the 2FA prompt. The trusted publisher on npmjs.com must allow stage-publish.
- Version 0.5.1 everywhere (root, core, cli, plugin manifest, marketplace, plugin `npx` pin) and a CHANGELOG entry. No code change.

## Test plan

- [x] `pnpm --filter @stroq/cli pack`: tarball contains `DISCLOSURE LICENSE README.md dist/ package.json`, `contentPolicy` present
- [x] `pnpm format:check` clean; `release.yml` parses (11 steps)
- [ ] CI green
- [ ] After merge: `pnpm build && pnpm --filter @stroq/cli publish --access public --otp <code>` from a logged-in maintainer account (interactive 2FA), then `npm view @stroq/cli version` → 0.5.1 once scanning completes; then tag `v0.5.1` + GitHub Release