### PR TITLE
docs: install from the release tarball while npm review holds a version

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ npx @stroq/cli doctor                # check the installation
 
 Prefer a persistent install? `npm install -g @stroq/cli` installs the `stroq` command globally — then run `stroq init` and `stroq doctor` directly.
 
+**If npm serves an older version than the [latest release](https://github.com/AGGIB/Stroq/releases/latest)** — npm's publish-time review can hold a new version of a security tool for a while — install the release tarball directly; it is the same package that goes to npm, built from the tagged commit:
+
+```bash
+npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.6.0/stroq-cli-0.6.0.tgz
+```
+
 ### Cursor
 
 ```bash


### PR DESCRIPTION
npm's publish-time review has held every `@stroq/cli` version since 0.3.0 (all are `validating`; 0.6.0 is staged and validating). Until it clears, `npx @stroq/cli init` installs 0.1.0, which has none of the documented features.

This adds one paragraph to the README's Install section pointing at the release tarball attached to [v0.6.0](https://github.com/AGGIB/Stroq/releases/tag/v0.6.0) — `stroq-cli-0.6.0.tgz`, packed from the tagged commit, sha256 `72bbc4e963d4013ac19d15b553799dc82d82c315cbf3b05fc6fd73b3b9b271bb`. Installing it into a clean prefix and running `stroq attack` gives `12 scenarios: 8 blocked, 4 asked, 0 passed through`.

- [x] prettier check clean
- [ ] CI green