### PR TITLE
docs: release-tarball install line → v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Prefer a persistent install? `npm install -g @stroq/cli` installs the `stroq` co
 **If npm serves an older version than the [latest release](https://github.com/AGGIB/Stroq/releases/latest)** — npm's publish-time review can hold a new version of a security tool for a while — install the release tarball directly; it is the same package that goes to npm, built from the tagged commit:
 
 ```bash
-npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.6.0/stroq-cli-0.6.0.tgz
+npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.7.0/stroq-cli-0.7.0.tgz
 ```
 
 ### Cursor


### PR DESCRIPTION
Points the README's npm-independent install line at the v0.7.0 tarball (sha256 `7bd79f592ca48a72d22d170b10fc0b58edc1d4c6930ad46861b89fbb2286db59`, attached to the release; installs into a clean prefix with `stroq attack` at 12/12 and `doctor` showing the OpenClaw line).

- [x] prettier clean
- [ ] CI green