### PR TITLE
chore(release): 0.8.0 — versions, changelog date, plugin and npx pins, supported versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
   "metadata": {
     "description": "Stroq — local action firewall for AI coding agents",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "plugins": [
     {
       "name": "stroq",
       "source": "./plugins/stroq",
       "description": "Local action firewall for Claude Code: content scan + session taint, instruction provenance, secret egress guard, ordered policy, hash-chained audit. Runs offline through native hooks.",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "homepage": "https://stroq.vercel.app",
       "license": "Apache-2.0",
       "keywords": ["security", "firewall", "prompt-injection", "secrets", "provenance", "audit"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-09-07
 
 ### Added
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,10 @@ Stroq is a security product: its job is to block specific dangerous actions once
 
 | Version | Supported |
 | ------- | --------- |
-| 0.7.x   | Yes       |
-| < 0.7   | No        |
+| 0.8.x   | Yes       |
+| < 0.8   | No        |
 
-Stroq is pre-1.0. Only the latest published `0.7.x` release is supported; please reproduce against the latest version before reporting.
+Stroq is pre-1.0. Only the latest published `0.8.x` release is supported; please reproduce against the latest version before reporting.
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stroq-monorepo",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/openclaw-plugin/openclaw.plugin.json
+++ b/packages/cli/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "stroq",
   "name": "Stroq",
   "description": "Local action firewall for OpenClaw: scans what the agent reads, taints the session, blocks or asks before dangerous tool calls.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/cli/openclaw-plugin/package.json
+++ b/packages/cli/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stroq-openclaw-plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Stroq's OpenClaw plugin entry: forwards before_tool_call and after_tool_call to the Stroq CLI.",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroq/cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Local action firewall for AI agents: scans what the agent reads, taints the session, blocks dangerous follow-up actions",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroq/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Stroq core: normalizer, ATR-compatible rule matcher, action classifier, taint-aware policy, audit chain",
   "license": "Apache-2.0",
   "private": true,

--- a/plugins/stroq/.claude-plugin/plugin.json
+++ b/plugins/stroq/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stroq",
   "description": "Local action firewall for Claude Code: scans what the agent reads, taints the session, attributes commands to the content they came from, denies outbound calls that carry your secrets, and asks before destructive or external actions. Deterministic, offline, hash-chained audit.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
   "homepage": "https://stroq.vercel.app",
   "repository": "https://github.com/AGGIB/Stroq",

--- a/plugins/stroq/hooks/stroq-hook.sh
+++ b/plugins/stroq/hooks/stroq-hook.sh
@@ -13,7 +13,7 @@
 # "block". PostToolUse events fail open in that case, because the tool has
 # already run and there is nothing left to block.
 set -u
-STROQ_PIN="@stroq/cli@0.7.0"
+STROQ_PIN="@stroq/cli@0.8.0"
 
 input="$(cat)"
 


### PR DESCRIPTION
## Summary

Cuts 0.8.0 — the Windsurf adapter (PR #29).

- Version `0.8.0` in the root, `@stroq/core`, `@stroq/cli`, the Claude Code plugin manifest and marketplace, the plugin's `npx` pin, and the OpenClaw plugin's `package.json` and manifest.
- `CHANGELOG.md`: `[Unreleased]` → `[0.8.0] - 2026-09-07`.
- `SECURITY.md`: supported versions `0.8.x`.

## Test plan

- [x] prettier clean on every bumped file
- [x] full suite on the release tree: 84 files, 1489 tests
- [x] `stroq-cli-0.8.0.tgz` packed from the built tree and smoke-tested from a clean prefix (`stroq attack` 12/12, `doctor` lists six agent lines)
- [ ] CI green
- [ ] tag `v0.8.0`, GitHub Release with the tarball, npm staging (2FA approval on npmjs.com)
