### PR TITLE
docs: release-tarball install line → v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Prefer a persistent install? `npm install -g @stroq/cli` installs the `stroq` co
 **If npm serves an older version than the [latest release](https://github.com/AGGIB/Stroq/releases/latest)** — npm's publish-time review can hold a new version of a security tool for a while — install the release tarball directly; it is the same package that goes to npm, built from the tagged commit:
 
 ```bash
-npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.7.0/stroq-cli-0.7.0.tgz
+npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.8.0/stroq-cli-0.8.0.tgz
 ```
 
 ### Cursor


### PR DESCRIPTION
Points the README's npm-independent install line at the v0.8.0 tarball (sha256 `e26b4159a5e4d58fb2a4b26bd220e253e5ea65f912a6be72e81059657f1875a2`, attached to the release; installed into a clean prefix with `stroq attack` at 12/12 and `doctor` listing the Windsurf line).

- [x] prettier clean
- [ ] CI green