### PR TITLE
docs: release-tarball install line → v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Prefer a persistent install? `npm install -g @stroq/cli` installs the `stroq` co
 **If npm serves an older version than the [latest release](https://github.com/AGGIB/Stroq/releases/latest)** — npm's publish-time review can hold a new version of a security tool for a while — install the release tarball directly; it is the same package that goes to npm, built from the tagged commit:
 
 ```bash
-npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.8.0/stroq-cli-0.8.0.tgz
+npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.9.0/stroq-cli-0.9.0.tgz
 ```
 
 ### Cursor


### PR DESCRIPTION
Points the README's npm-independent install line at the v0.9.0 tarball attached to the GitHub Release (sha256 8761a5c2365e14c6467eaf9dcdd05bda770d70ac617463b7edf2023528746480; installed into a clean prefix with stroq attack at 12/12, doctor showing the mcp proxy line, init --agent mcp --dry-run producing the wrapper).

- [x] prettier clean
- [ ] CI green