### PR TITLE
docs: release-tarball install line → v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Prefer a persistent install? `npm install -g @stroq/cli` installs the `stroq` co
 **If npm serves an older version than the [latest release](https://github.com/AGGIB/Stroq/releases/latest)** — npm's publish-time review can hold a new version of a security tool for a while — install the release tarball directly; it is the same package that goes to npm, built from the tagged commit:
 
 ```bash
-npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.9.0/stroq-cli-0.9.0.tgz
+npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.10.0/stroq-cli-0.10.0.tgz
 ```
 
 ### Cursor


### PR DESCRIPTION
Points the README's npm-independent install line at the v0.10.0 tarball attached to the GitHub Release (sha256 e19868334d72ee301f2b9e1058847649bb19bcf0166fe1a6860bcd9453172d6d).

- [x] prettier clean
- [ ] CI green