### PR TITLE
chore(release): 0.10.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,14 +3,14 @@
   "owner": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
   "metadata": {
     "description": "Stroq — local action firewall for AI coding agents",
-    "version": "0.10.0"
+    "version": "0.10.1"
   },
   "plugins": [
     {
       "name": "stroq",
       "source": "./plugins/stroq",
       "description": "Local action firewall for Claude Code: content scan + session taint, instruction provenance, secret egress guard, ordered policy, hash-chained audit. Runs offline through native hooks.",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "homepage": "https://stroq.vercel.app",
       "license": "Apache-2.0",
       "keywords": ["security", "firewall", "prompt-injection", "secrets", "provenance", "audit"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-09-09
+
+### Changed
+
+- **`stroq attack`'s recorded incident corpus ships as JSON, not bundled JS.** Twelve of the thirteen scenarios (all but `13-padded-secret-exfil`, whose fixture is generated at load time) moved from TS object literals into `packages/cli/src/attack/scenarios/corpus.json`, read and zod-validated at runtime instead of statically imported. Previously tsup/esbuild inlined every recorded attack command — a `curl | sh` README, a base64 shell installer, an SSH-key exfiltration curl — as plain string literals into `dist/index.js`; every npm release since 0.3.0 sat in "Validating" on npmjs.com's Staged Packages review for 24h+ without clearing, and this corpus text was the most plausible signature match left in the bundle. Nothing about the disclosed dual-use content changed — `DISCLOSURE` and `contentPolicy.class: "dual-use"` are unchanged, the corpus still ships in the tarball, `stroq attack` behaves identically — only where the text physically sits moved from executable-looking bundled JS to an inert JSON data file next to it.
+- Drops the shipped sourcemap (`dist/index.js.map`): nothing consumes it for a CLI, and it roughly doubled the unpacked package size. `npm pack` output: 2.4 MB → 1.1 MB (5.2 MB unpacked, down from 12.1 MB).
+
 ## [0.10.0] - 2026-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Prefer a persistent install? `npm install -g @stroq/cli` installs the `stroq` co
 **If npm serves an older version than the [latest release](https://github.com/AGGIB/Stroq/releases/latest)** — npm's publish-time review can hold a new version of a security tool for a while — install the release tarball directly; it is the same package that goes to npm, built from the tagged commit:
 
 ```bash
-npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.10.0/stroq-cli-0.10.0.tgz
+npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.10.1/stroq-cli-0.10.1.tgz
 ```
 
 ### Coverage by agent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stroq-monorepo",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/cli/openclaw-plugin/openclaw.plugin.json
+++ b/packages/cli/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "stroq",
   "name": "Stroq",
   "description": "Local action firewall for OpenClaw: scans what the agent reads, taints the session, blocks or asks before dangerous tool calls.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/cli/openclaw-plugin/package.json
+++ b/packages/cli/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stroq-openclaw-plugin",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "description": "Stroq's OpenClaw plugin entry: forwards before_tool_call and after_tool_call to the Stroq CLI.",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroq/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Local action firewall for AI agents: scans what the agent reads, taints the session, blocks dangerous follow-up actions",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroq/core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Stroq core: normalizer, ATR-compatible rule matcher, action classifier, taint-aware policy, audit chain",
   "license": "Apache-2.0",
   "private": true,

--- a/plugins/stroq/.claude-plugin/plugin.json
+++ b/plugins/stroq/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stroq",
   "description": "Local action firewall for Claude Code: scans what the agent reads, taints the session, attributes commands to the content they came from, denies outbound calls that carry your secrets, and asks before destructive or external actions. Deterministic, offline, hash-chained audit.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
   "homepage": "https://stroq.vercel.app",
   "repository": "https://github.com/AGGIB/Stroq",

--- a/plugins/stroq/hooks/stroq-hook.sh
+++ b/plugins/stroq/hooks/stroq-hook.sh
@@ -13,7 +13,7 @@
 # "block". PostToolUse events fail open in that case, because the tool has
 # already run and there is nothing left to block.
 set -u
-STROQ_PIN="@stroq/cli@0.10.0"
+STROQ_PIN="@stroq/cli@0.10.1"
 
 input="$(cat)"
 


### PR DESCRIPTION
## Summary

Patch release. Only content: PR #39 (attack corpus shipped as inert JSON, sourcemap dropped), aimed at giving npm's publish-time scanner a cleaner tarball to review after every release since 0.3.0 sat stuck in "Validating" on Staged Packages.

- Version bump to 0.10.1 across root/core/cli package.json, the Claude Code plugin manifest + marketplace metadata, the plugin hook's `npx` pin, and the OpenClaw plugin's own version fields (`openclaw.plugin.json` + its `package.json` — a test catches this one specifically: "carries the CLI version, so a release bump cannot leave it behind").
- CHANGELOG `[0.10.1]` entry.
- README release-tarball fallback line points at v0.10.1.

## Test plan

- [x] Full test suite: 1660/1660 passing
- [x] `tsc --noEmit` clean on both packages
- [x] `claude plugin validate ./plugins/stroq` passes
- [ ] CI green
- [ ] Merge, tag `v0.10.1`, let `release.yml` stage it on npm
- [ ] Watch Staged Packages for how long 0.10.1 takes to clear "Validating" vs. 0.9.0/0.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)