### PR TITLE
docs: drop the npm-review-holdup tarball fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,6 @@ npx @stroq/cli doctor                # check the installation
 
 Prefer a persistent install? `npm install -g @stroq/cli` installs the `stroq` command globally — then run `stroq init` and `stroq doctor` directly.
 
-**If npm serves an older version than the [latest release](https://github.com/AGGIB/Stroq/releases/latest)** — npm's publish-time review can hold a new version of a security tool for a while — install the release tarball directly; it is the same package that goes to npm, built from the tagged commit:
-
-```bash
-npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.10.1/stroq-cli-0.10.1.tgz
-```
-
 ### Coverage by agent
 
 What each host lets Stroq do, in one table. The sections that follow give the full event tables and every documented limit.

--- a/site/index.html
+++ b/site/index.html
@@ -611,7 +611,6 @@ seq 42  <span class="sp-dim">prev</span> 3e1c…f0a2  <span class="sp-allow">cha
       <div class="section-head section-head-stack reveal">
         <h2 id="install-title">One command to install.</h2>
         <p class="section-lead">Requires Node 22 or newer. <code>init</code> writes Claude Code's hooks into your project's <code>.claude/settings.json</code>; <code>--agent cursor</code>, <code>codex</code>, <code>copilot</code>, <code>windsurf</code> or <code>openclaw</code> installs for those agents, and <code>--agent mcp --client claude-desktop</code> wraps a client's MCP servers in the proxy. Pass <code>--user</code> to install for every project, or <code>--dry-run</code> to preview the change. Then restart the agent in that project.</p>
-        <p class="section-lead">If npm serves an older version than the <a href="https://github.com/AGGIB/Stroq/releases/latest">latest release</a>, install the tarball attached to that release instead: <code>npm install -g https://github.com/AGGIB/Stroq/releases/download/v0.10.0/stroq-cli-0.10.0.tgz</code>. It is the same package, built from the tagged commit.</p>
         <p class="install-note"><strong>We never suggest <code>curl | sh</code>.</strong> That is the pattern Stroq exists to stop.</p>
       </div>
       <div class="install-blocks">


### PR DESCRIPTION
## Summary

`@stroq/cli` 0.10.1 is live on npm as `latest` — verified with `npm view @stroq/cli dist-tags` and a real `npx @stroq/cli@0.10.1 doctor` run. The GitHub-release-tarball fallback instructions in the README and the site (added while every release since 0.3.0 sat stuck in npm's Staged Packages review) are no longer needed.

- README: removed the "If npm serves an older version..." paragraph and its tarball install command
- site: removed the matching install-section paragraph

## Test plan

- [x] `npm view @stroq/cli dist-tags` → `{ "latest": "0.10.1" }`
- [x] `npx @stroq/cli@0.10.1 doctor` runs correctly from the registry
- [x] prettier clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)