### PR TITLE
docs: point the site links at stroq.dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "source": "./plugins/stroq",
       "description": "Local action firewall for Claude Code: content scan + session taint, instruction provenance, secret egress guard, ordered policy, hash-chained audit. Runs offline through native hooks.",
       "version": "0.10.1",
-      "homepage": "https://stroq.vercel.app",
+      "homepage": "https://stroq.dev",
       "license": "Apache-2.0",
       "keywords": ["security", "firewall", "prompt-injection", "secrets", "provenance", "audit"],
       "category": "security"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx @stroq/cli init
 
 Supported today: **Claude Code**, **Cursor**, **Codex**, **Copilot CLI**, **Windsurf** (native hooks) · **OpenClaw** (in-process plugin) · **any MCP client** (stdio proxy)
 
-**Website:** [stroq.vercel.app](https://stroq.vercel.app)
+**Website:** [stroq.dev](https://stroq.dev)
 
 </div>
 

--- a/plugins/stroq/.claude-plugin/plugin.json
+++ b/plugins/stroq/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Local action firewall for Claude Code: scans what the agent reads, taints the session, attributes commands to the content they came from, denies outbound calls that carry your secrets, and asks before destructive or external actions. Deterministic, offline, hash-chained audit.",
   "version": "0.10.1",
   "author": { "name": "AGGIB", "url": "https://github.com/AGGIB" },
-  "homepage": "https://stroq.vercel.app",
+  "homepage": "https://stroq.dev",
   "repository": "https://github.com/AGGIB/Stroq",
   "license": "Apache-2.0",
   "keywords": [

--- a/site/index.html
+++ b/site/index.html
@@ -5,23 +5,23 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Stroq — local action firewall for AI coding agents</title>
 <meta name="description" content="Stroq scans what your AI coding agent reads, taints the session, and deterministically blocks the dangerous follow-up action — locally, with a hash-chained audit log. Open source, Apache-2.0. One command to install into Claude Code, Cursor, Codex, Copilot CLI, Windsurf, OpenClaw or any MCP client.">
-<link rel="canonical" href="https://stroq.vercel.app/">
+<link rel="canonical" href="https://stroq.dev/">
 <meta name="color-scheme" content="light dark">
 <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f4f3ee">
 <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0e0f12">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Stroq">
-<meta property="og:url" content="https://stroq.vercel.app/">
+<meta property="og:url" content="https://stroq.dev/">
 <meta property="og:title" content="Stroq — local action firewall for AI coding agents">
 <meta property="og:description" content="Scans what the agent reads, taints the session, blocks the dangerous follow-up — before anything leaves your machine. Open source, Apache-2.0.">
-<meta property="og:image" content="https://stroq.vercel.app/assets/social-preview.png">
+<meta property="og:image" content="https://stroq.dev/assets/social-preview.png">
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="Stroq — local action firewall for AI coding agents">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Stroq — local action firewall for AI coding agents">
 <meta name="twitter:description" content="Scans what the agent reads, taints the session, blocks the dangerous follow-up — before anything leaves your machine. Open source, Apache-2.0.">
-<meta name="twitter:image" content="https://stroq.vercel.app/assets/social-preview.png">
+<meta name="twitter:image" content="https://stroq.dev/assets/social-preview.png">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary

Attached `stroq.dev` (Vercel-registered, DNS already verified) to the `stroq` Vercel project — it's live now (`curl -I https://stroq.dev` → 200, same CSP headers as the old domain). `www.stroq.dev` is attached too. `stroq.vercel.app` keeps working (Vercel's default project domain, can't be removed) but nothing in the repo points at it anymore.

- README website link
- Claude Code plugin manifest `homepage`
- Marketplace metadata `homepage`
- site's canonical URL, `og:url`, `og:image`, `twitter:image`

## Test plan

- [x] `curl -I https://stroq.dev` → 200
- [x] prettier clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)